### PR TITLE
Add `.gitleaksignore` file for the nightlights utils

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,2 @@
+818f8620eb8a3c9df0243b7128e153afc1e86f4b:src/nightlights.py:generic-api-key:59
+6f89562b01a9cadc655d215b8fce31c0e1c4cf45:src/nightlights.py:generic-api-key:59


### PR DESCRIPTION
## What does this PR do?

Adds a `.gitleaksignore` file to flag that the secret for the nightlights utils is a generic API key and should be fine to keep. 

## Where should the reviewers start?

`.gitleaksignore`